### PR TITLE
Enabled thread_pool in dataloader to resolve hang issue

### DIFF
--- a/scripts/instance/mask_rcnn/train_mask_rcnn.py
+++ b/scripts/instance/mask_rcnn/train_mask_rcnn.py
@@ -324,7 +324,7 @@ def get_dataloader(net, train_dataset, val_dataset, train_transform, val_transfo
                                                 shuffle=True)
     train_loader = mx.gluon.data.DataLoader(train_dataset.transform(
         train_transform(net.short, net.max_size, net, ashape=net.ashape, multi_stage=args.use_fpn)),
-        batch_sampler=train_sampler, batchify_fn=train_bfn, num_workers=args.num_workers)
+        batch_sampler=train_sampler, batchify_fn=train_bfn, num_workers=args.num_workers, thread_pool=True)
     val_bfn = batchify.Tuple(*[batchify.Append() for _ in range(2)])
     short = net.short[-1] if isinstance(net.short, (tuple, list)) else net.short
     # validation use 1 sample per device


### PR DESCRIPTION
- While using multiprocessing.pool, the dataloader gets hang non-deterministically during first pre-fetching of batch.
- However, using thread_pool resolve those issues.

**Testing**:
- Ran the script with full training 4 times and partial (only 1 epoch) 6 times and didn't observed a hang.
- Ran the script 5 times on different cluster too and didn't observed a hang.
- Using `thread_pool` shows 15% drops in throughput as compared to `multiprocessing.pool`