### PR TITLE
maskrcnn - training - log throughput per epoch

### DIFF
--- a/scripts/instance/mask_rcnn/train_mask_rcnn.py
+++ b/scripts/instance/mask_rcnn/train_mask_rcnn.py
@@ -542,6 +542,8 @@ def train(net, train_data, val_data, eval_metric, batch_size, ctx, logger, args)
             metric.reset()
         tic = time.time()
         btic = time.time()
+        speed = []
+        avg_batch_speed = 0
         train_data_iter = iter(train_data)
         next_data_batch = next(train_data_iter)
         next_data_batch = split_and_load(next_data_batch, ctx_list=ctx)
@@ -587,14 +589,18 @@ def train(net, train_data, val_data, eval_metric, batch_size, ctx, logger, args)
             if (not args.smdataparallel or dist.rank() == 0) and args.log_interval \
                     and not (i + 1) % args.log_interval:
                 msg = ','.join(['{}={:.3f}'.format(*metric.get()) for metric in metrics + metrics2])
+                batch_speed = args.log_interval * args.batch_size / (time.time() - btic)
+                speed.append(batch_speed)
                 logger.info('[Epoch {}][Batch {}], Speed: {:.3f} samples/sec, {}'.format(
-                    epoch, i, args.log_interval * args.batch_size / (time.time() - btic), msg))
+                    epoch, i, batch_speed, msg))
                 btic = time.time()
+        if speed:
+            avg_batch_speed = sum(speed)/len(speed)
         # validate and save params
         if (not args.smdataparallel) or dist.rank() == 0:
             msg = ','.join(['{}={:.3f}'.format(*metric.get()) for metric in metrics])
-            logger.info('[Epoch {}] Training cost: {:.3f}, {}'.format(
-                epoch, (time.time() - tic), msg))
+            logger.info('[Epoch {}] Training cost: {:.3f}, Speed: {:.3f} samples/sec, {}'.format(
+                epoch, (time.time() - tic), avg_batch_speed, msg))
         if not (epoch + 1) % args.val_interval:
             # consider reduce the frequency of validation to save time
             validate(net, val_data, async_eval_processes, ctx, eval_metric, logger, epoch, best_map,


### PR DESCRIPTION
returns avg speed in samples/sec at the end of training each epoch

Previously output was
```
[Epoch 3] Training cost: 557.830, RPN_Conf=0.044,RPN_SmoothL1=0.039,RCNN_CrossEntropy=0.533,RCNN_SmoothL1=0.273,RCNN_Mask=0.600
[1,0]<stderr>:INFO:root:[Epoch 3] Validation Inference cost: 33.576
```

Now
```
[Epoch 3] Training cost: 557.830, Speed: 209.766 samples/sec, RPN_Conf=0.044,RPN_SmoothL1=0.039,RCNN_CrossEntropy=0.533,RCNN_SmoothL1=0.273,RCNN_Mask=0.600
[1,0]<stderr>:INFO:root:[Epoch 3] Validation Inference cost: 33.576
```